### PR TITLE
Accept tags via variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,16 @@ module "secret_area_auth" {
   source = "github.com/rstudio/edge-auth"
 
   known_users = {
-    jet = "fuel"
+    jet   = "fuel"
     steel = "beams"
   }
 
   name_prefix = "secret-area"
+
+  tags = {
+    "com.example.serious/unit"    = "secrets"
+    "com.example.serious/purpose" = "secrecy"
+  }
 }
 
 resource "aws_cloudfront_distribution" "secret_area" {

--- a/main.tf
+++ b/main.tf
@@ -44,9 +44,10 @@ data "aws_iam_policy_document" "lambda_assume_role" {
 }
 
 resource "aws_iam_role" "lambda" {
-  name = "${var.name_prefix}-edge-auth-lambda-role"
-
+  name               = "${var.name_prefix}-edge-auth-lambda-role"
   assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+
+  tags = merge({ Name = "${var.name_prefix}-edge-auth-lambda-role" }, var.tags)
 }
 
 resource "aws_lambda_function" "lambda" {

--- a/main.tf
+++ b/main.tf
@@ -6,9 +6,16 @@ variable "name_prefix" {
   type = string
 }
 
+variable "tags" {
+  type = map(string)
+  default = {
+    "github-repo" = "github.com/rstudio/edge-auth"
+  }
+}
+
 data "archive_file" "zip" {
   type        = "zip"
-  output_path = "${path.cwd}/edge_auth.zip"
+  output_path = "${path.cwd}/${var.name_prefix}-edge_auth.zip"
 
   source {
     content  = <<-EDGEAUTHPY
@@ -54,6 +61,8 @@ resource "aws_lambda_function" "lambda" {
   lifecycle {
     create_before_destroy = true
   }
+
+  tags = merge({ Name = "${var.name_prefix}-edge-auth-lambda" }, var.tags)
 }
 
 output "lambda_arn" {


### PR DESCRIPTION
and name the archive file differently depending on the name prefix for cases where multiple uses of the module are in the same working dir.

The purpose of accepting `tags` as a module variable is so that the `aws_iam_role.lambda` and `aws_lambda_function.lambda` resources are created with tags that comply with whatever tagging requirements one might have, e.g.:

```hcl
module "secret_area_auth" {
  source = "github.com/rstudio/edge-auth"

  known_users = {
    jet = "fuel"
  }
  name_prefix = "secret-area"
  
  tags = {
    "serious-business/compliance" = "squirrel"
    "com.example.biz-unit"        = "probably-sales"
  }
}
```