### PR TITLE
Use relative path for archive output

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@ variable "tags" {
 
 data "archive_file" "zip" {
   type        = "zip"
-  output_path = "${path.cwd}/${var.name_prefix}-edge_auth.zip"
+  output_path = "${var.name_prefix}-edge_auth.zip"
 
   source {
     content  = <<-EDGEAUTHPY


### PR DESCRIPTION
to alleviate churn caused by path changes in state
see: https://github.com/hashicorp/terraform/issues/8534